### PR TITLE
Do not extract comment only interpolations

### DIFF
--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -32,7 +32,9 @@ module Ruumba
     # @param [String] filename The filename.
     # @return [String] The extracted Ruby code.
     def extract(filename)
-      File.read(filename).scan(ERB_REGEX).map(&:last).map(&:strip).join("\n")
+      File.read(filename).scan(ERB_REGEX).map(&:last)
+        .reject { |line| line[0] == '#' }
+        .map(&:strip).join("\n")
     end
 
     private

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -36,6 +36,37 @@ describe Ruumba::Analyzer do
       expect(analyzer.extract('multi.erb')).to eq("puts 'foo'\nbar")
     end
 
+    it 'does extract single line ruby comments from an ERB template' do
+      comment = <<-EOF
+<% puts 'foo'
+# that puts is ruby code
+bar %>
+EOF
+
+      allow(File).to receive(:read).with('comment.erb') { comment }
+
+      parsed = <<-EOF
+puts 'foo'
+# that puts is ruby code
+bar
+EOF
+      parsed = parsed.strip
+
+      expect(analyzer.extract('comment.erb')).to eq(parsed)
+    end
+
+    it 'does not extract ruby comments from interpolated code' do
+      comment = <<-EOF
+        <%# this is a multiline comment
+            interpolated in the ERB template
+            it should resolve to nothing %>
+      EOF
+
+      allow(File).to receive(:read).with('comment.erb') { comment }
+
+      expect(analyzer.extract('comment.erb')).to eq('')
+    end
+
     it 'does not extract code from lines without ERB interpolation' do
       none = "<h1>Dead or alive, you're coming with me.</h1>"
       allow(File).to receive(:read).with('none.erb') { none }


### PR DESCRIPTION
I have seen comments (multiline ones) which are wrapped in ERB templates
like this:

```
<%# here is some comment
    it carries on to this line
    and more
%>
```

Doing a comment this way does not include it in the final HTML which
would be the case when using html comments. If ruumba extracts this,
since it is multiline, it is actually invalid ruby code.

I have updated the parsing code to just throw away lines which begin
with a '#'.