### PR TITLE
Don't blow up linting <%== in erb

### DIFF
--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -32,7 +32,9 @@ module Ruumba
     # @param [String] filename The filename.
     # @return [String] The extracted Ruby code.
     def extract(filename)
-      File.read(filename).scan(ERB_REGEX).map(&:last)
+      # http://edgeguides.rubyonrails.org/active_support_core_extensions.html#output-safety
+      # replace '<%==' with '<%= raw' to avoid generating invalid ruby code
+      File.read(filename).gsub(/<%==/, '<%= raw').scan(ERB_REGEX).map(&:last)
         .reject { |line| line[0] == '#' }
         .map(&:strip).join("\n")
     end

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -67,6 +67,17 @@ EOF
       expect(analyzer.extract('comment.erb')).to eq('')
     end
 
+    it 'extracts and converts lines using <%== for the raw helper' do
+      comment = <<-EOF
+        <span class="test" <%== 'style="display: none;"' if num.even? %>>
+      EOF
+
+      allow(File).to receive(:read).with('comment.erb') { comment }
+
+      expect(analyzer.extract('comment.erb'))
+        .to eq("raw 'style=\"display: none;\"' if num.even?")
+    end
+
     it 'does not extract code from lines without ERB interpolation' do
       none = "<h1>Dead or alive, you're coming with me.</h1>"
       allow(File).to receive(:read).with('none.erb') { none }


### PR DESCRIPTION
This is equivalent to the raw helper, so temporarily replace it with
this after extracting from the template.