### PR TITLE
Make output filenames match real filenames

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,12 @@ Metrics/MethodLength:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Metrics/CyclomaticComplexity:
+  Max: 10

--- a/bin/ruumba
+++ b/bin/ruumba
@@ -67,4 +67,4 @@ rescue OptionParser::InvalidOption => e
 end
 
 analyzer = Ruumba::Analyzer.new(options)
-analyzer.run
+exit(analyzer.run)

--- a/bin/ruumba
+++ b/bin/ruumba
@@ -22,15 +22,17 @@ opts_parser = OptionParser.new do |opts|
   end
 
   opts.on('-c', '--config [CONFIG]', 'Use this config for rubocop') do |c|
-    options[:arguments] << "--config #{File.expand_path(c)}"
+    options[:arguments] << '--config'
+    options[:arguments] << File.expand_path(c)
   end
 
   opts.on('-D', '--display-cop-names', 'Display cop names') do ||
-    options[:arguments] << "--display-cop-names"
+    options[:arguments] << '--display-cop-names'
   end
 
   opts.on('-F', '--fail-level [LEVEL]', 'Rubocop fail level') do |l|
-    options[:arguments] << "--fail-level #{l}"
+    options[:arguments] << '--fail-level'
+    options[:arguments] << l
   end
 
   opts.on('-e', '--disable-ruby-ext', 'Disable auto-append of .rb extension') do
@@ -38,24 +40,29 @@ opts_parser = OptionParser.new do |opts|
   end
 
   opts.on('--only [COP1,COP2,...]', 'Run only the given cop(s).') do |cops|
-    options[:arguments] << "--only #{cops}"
+    options[:arguments] << '--only'
+    options[:arguments] << cops
   end
 
   opts.on('-r', '--require [FILE]', 'Require Ruby file.') do |file|
-    options[:arguments] << "--require #{file}"
+    options[:arguments] << '--require'
+    options[:arguments] << file
   end
 
   opts.on('-o', '--out [FILE]', 'Write output to a file instead of STDOUT.') do |file|
-    options[:arguments] << "--out #{file}"
+    options[:arguments] << '--out'
+    options[:arguments] << file
   end
 
   opts.on('-f', '--format [FORMAT]', 'Choose an output formatter.') do |format|
-    options[:arguments] << "--format #{format}"
+    options[:arguments] << '--format'
+    options[:arguments] << format
   end
 end
 
-begin opts_parser.parse!
-  rescue OptionParser::InvalidOption => e
+begin
+  opts_parser.parse!
+rescue OptionParser::InvalidOption => e
   abort "An error occurred: #{e}. Run ruumba -h for help."
 end
 

--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -122,7 +122,7 @@ module Ruumba
         replacements << [/\.erb\.rb/, '.erb']
       end
 
-      Dir.chdir(tmp) do
+      result = Dir.chdir(tmp) do
         stdout, stderr, status = Open3.capture3(*args)
 
         munge_output(stdout, stderr, replacements)
@@ -132,6 +132,8 @@ module Ruumba
 
       FileUtils.cp(todo, pwd) if File.exist?(todo)
       FileUtils.rm_rf(tmp) unless @options[:tmp_folder]
+
+      result
     end
 
     def munge_output(stdout, stderr, replacements)

--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -3,6 +3,8 @@
 require 'securerandom'
 require 'pathname'
 require 'tmpdir'
+require 'open3'
+require 'English'
 
 # Ruumba: RuboCop's sidekick.
 module Ruumba
@@ -107,12 +109,40 @@ module Ruumba
     end
 
     def run_rubocop(target, tmp)
-      args = (@options[:arguments] || []).join(' ')
+      args = ['rubocop'] + (@options[:arguments] || []) + [target.to_s]
       todo = tmp + '.rubocop_todo.yml'
 
-      system("cd #{tmp} && rubocop #{args} #{target}").tap do
-        FileUtils.cp(todo, ENV['PWD']) if File.exist?(todo)
-        FileUtils.rm_rf(tmp) unless @options[:tmp_folder]
+      pwd = ENV['PWD']
+
+      replacements = []
+
+      replacements << [/^#{Regexp.quote(tmp.to_s)}/, pwd]
+
+      unless @options[:disable_rb_extension]
+        replacements << [/\.erb\.rb/, '.erb']
+      end
+
+      Dir.chdir(tmp) do
+        stdout, stderr, status = Open3.capture3(*args)
+
+        munge_output(stdout, stderr, replacements)
+
+        status.exitstatus
+      end
+
+      FileUtils.cp(todo, pwd) if File.exist?(todo)
+      FileUtils.rm_rf(tmp) unless @options[:tmp_folder]
+    end
+
+    def munge_output(stdout, stderr, replacements)
+      [[STDOUT, stdout], [STDERR, stderr]].each do |output_stream, output|
+        next if output.nil? || output.empty?
+
+        replacements.each do |pattern, replacement|
+          output.gsub!(pattern, replacement)
+        end
+
+        output_stream.puts(output)
       end
     end
   end

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -7,8 +7,11 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
 
   describe '#run' do
     it 'analyzes the provided ERB files' do
-      allow(Kernel).to receive(:system).and_return('success')
-      expect(analyzer).to receive(:system)
+      status = double
+      expect(status).to receive(:exitstatus).and_return(0)
+
+      results = ['', '', status]
+      expect(Open3).to receive(:capture3).and_return(results)
 
       analyzer.run(['foo'])
     end


### PR DESCRIPTION
When using a custom --format argument, always replace the tmp dir path.
Many formatters will output the absolute filename.

Additionally, when the \.rb extension is added to filenames, make sure
to strip it back off in the output.