### PR TITLE
Support calling ruumba with explicit files / directories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Metrics/PerceivedComplexity:
 
 Metrics/CyclomaticComplexity:
   Max: 10
+
+Metrics/ClassLength:
+  Max: 120

--- a/bin/ruumba
+++ b/bin/ruumba
@@ -26,6 +26,10 @@ opts_parser = OptionParser.new do |opts|
     options[:arguments] << File.expand_path(c)
   end
 
+  opts.on('-d', '--debug', 'Display debug info.') do ||
+    options[:arguments] << '--debug'
+  end
+
   opts.on('-D', '--display-cop-names', 'Display cop names') do ||
     options[:arguments] << '--display-cop-names'
   end


### PR DESCRIPTION
This feature should allow integration with tools which only want to lint
a single file. This could be implemented in flycheck for use in emacs
for example.

Additionally, we could only run ruumba on the changed files for a commit
on CI.