### PR TITLE
Fix exit status checking.

### DIFF
--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -127,7 +127,7 @@ module Ruumba
 
         munge_output(stdout, stderr, replacements)
 
-        status.exitstatus
+        status.success?
       end
 
       FileUtils.cp(todo, pwd) if File.exist?(todo)

--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -127,7 +127,7 @@ module Ruumba
 
         munge_output(stdout, stderr, replacements)
 
-        status.success?
+        status.exitstatus.zero?
       end
 
       FileUtils.cp(todo, pwd) if File.exist?(todo)

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -13,7 +13,7 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
       results = ['', '', status]
       expect(Open3).to receive(:capture3).and_return(results)
 
-      analyzer.run(['foo'])
+      expect(analyzer.run(['foo'])).to eq(true)
     end
   end
 


### PR DESCRIPTION
Since it won't `exit(1)` in https://github.com/ericqweinstein/ruumba/blob/8e4bfb8e0661f44e8530b7412f07e4743a516b98/lib/ruumba/rake_task.rb#L39 because `exitstatus` returns integer.

I need this to run ruumba on CI.