### PR TITLE
Rewrite <%= to not trigger Lint/Void cop

### DIFF
--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -100,7 +100,7 @@ module Ruumba
       file_text[start_index...end_index].tap do |region|
         region.gsub!(/./, ' ') if region[0] == '#'
 
-        region.sub!(/\A#{ERBOUT}/, '') if region.start_with?("#{ERBOUT} ") && region =~ BLOCK_EXPR
+        region.sub!(/\A#{ERBOUT}/, ' ' * ERBOUT.length) if region.start_with?("#{ERBOUT} ") && region =~ BLOCK_EXPR
       end
     end
 

--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -14,6 +14,9 @@ module Ruumba
     # The regular expression to capture interpolated Ruby.
     ERB_REGEX = /<%[-=]?(.*?)-?%>/m
 
+    # The regular expression used to detect blocks inside interpolated Ruby
+    BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
+
     def initialize(opts = nil)
       @options = opts || {}
     end
@@ -92,6 +95,8 @@ module Ruumba
     def extract_match(file_text, start_index, end_index)
       file_text[start_index...end_index].tap do |region|
         region.gsub!(/./, ' ') if region[0] == '#'
+
+        region.sub!(/\Aerb/, '') if region.start_with?("erb ") && region =~ BLOCK_EXPR
       end
     end
 

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -22,21 +22,21 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
       one = "<%= puts 'Hello, world!' %>"
       allow(File).to receive(:read).with('one.erb') { one }
 
-      expect(analyzer.extract('one.erb')).to eq("    puts 'Hello, world!'   ")
+      expect(analyzer.extract('one.erb')).to eq("erb puts 'Hello, world!'   ")
     end
 
     it 'extracts many lines of Ruby code from an ERB template' do
       many = "<%= puts 'foo' %>\n<%= puts 'bar' %>\n<% baz %>"
       allow(File).to receive(:read).with('many.erb') { many }
 
-      expect(analyzer.extract('many.erb')).to eq("    puts 'foo'   \n    puts 'bar'   \n   baz   ")
+      expect(analyzer.extract('many.erb')).to eq("erb puts 'foo'   \nerb puts 'bar'   \n   baz   ")
     end
 
     it 'extracts multiple interpolations per line' do
       multi = "<%= puts 'foo' %> then <% bar %>"
       allow(File).to receive(:read).with('multi.erb') { multi }
 
-      expect(analyzer.extract('multi.erb')).to eq("    puts 'foo' ;          bar   ")
+      expect(analyzer.extract('multi.erb')).to eq("erb puts 'foo' ;          bar   ")
     end
 
     it 'does extract single line ruby comments from an ERB template' do
@@ -79,7 +79,7 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
       allow(File).to receive(:read).with('comment.erb') { comment }
 
       expect(analyzer.extract('comment.erb'))
-        .to eq("#{' ' * 23}raw 'style=\"display: none;\"' if num.even?    \n")
+        .to eq("#{' ' * 20}erb 'style=\"display: none;\"' if num.even?    \n")
     end
 
     it 'does not extract code from lines without ERB interpolation' do

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -36,14 +36,14 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
       block = "<%= form_for @record do |foo| %>\n<%= puts 'bar' %>\n<% end %>"
       allow(File).to receive(:read).with('block.erb') { block }
 
-      expect(analyzer.extract('block.erb')).to eq("    form_for @record do |foo|   \nerb puts 'bar'   \n   end   ")
+      expect(analyzer.extract('block.erb')).to eq("       form_for @record do |foo|   \nerb puts 'bar'   \n   end   ")
     end
 
     it 'extracts Ruby line containing <%= ... {|n| %> from an ERB template' do
       block = "<%= form_for @record { |foo| %>\n<%= puts 'bar' %>\n<% } %>"
       allow(File).to receive(:read).with('block.erb') { block }
 
-      expect(analyzer.extract('block.erb')).to eq("    form_for @record { |foo|   \nerb puts 'bar'   \n   }   ")
+      expect(analyzer.extract('block.erb')).to eq("       form_for @record { |foo|   \nerb puts 'bar'   \n   }   ")
     end
 
     it 'extracts multiple interpolations per line' do

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -32,6 +32,20 @@ describe Ruumba::Analyzer do # rubocop:disable Metrics/BlockLength
       expect(analyzer.extract('many.erb')).to eq("erb puts 'foo'   \nerb puts 'bar'   \n   baz   ")
     end
 
+    it 'extracts Ruby line containing <%= ... do %> from an ERB template' do
+      block = "<%= form_for @record do |foo| %>\n<%= puts 'bar' %>\n<% end %>"
+      allow(File).to receive(:read).with('block.erb') { block }
+
+      expect(analyzer.extract('block.erb')).to eq("    form_for @record do |foo|   \nerb puts 'bar'   \n   end   ")
+    end
+
+    it 'extracts Ruby line containing <%= ... {|n| %> from an ERB template' do
+      block = "<%= form_for @record { |foo| %>\n<%= puts 'bar' %>\n<% } %>"
+      allow(File).to receive(:read).with('block.erb') { block }
+
+      expect(analyzer.extract('block.erb')).to eq("    form_for @record { |foo|   \nerb puts 'bar'   \n   }   ")
+    end
+
     it 'extracts multiple interpolations per line' do
       multi = "<%= puts 'foo' %> then <% bar %>"
       allow(File).to receive(:read).with('multi.erb') { multi }


### PR DESCRIPTION
Instances of <%= where the contents do not call a method to generate
the output will trigger the Lint/Void cop since rubocop does not see anything
handle the result of the code.

A simple fix is to replace this with an imaginary method erb which
luckily is also 3 characters long, keeping our column numbers intact.

Resolves #16