### PR TITLE
Use pwd after switching to temporary directory to replace paths in ou…

### DIFF
--- a/lib/ruumba/analyzer.rb
+++ b/lib/ruumba/analyzer.rb
@@ -124,17 +124,17 @@ module Ruumba
       args = ['rubocop'] + (@options[:arguments] || []) + [target.to_s]
       todo = tmp + '.rubocop_todo.yml'
 
-      pwd = ENV['PWD']
+      pwd = Dir.pwd
 
       replacements = []
-
-      replacements << [/^#{Regexp.quote(tmp.to_s)}/, pwd]
 
       unless @options[:disable_rb_extension]
         replacements << [/\.erb\.rb/, '.erb']
       end
 
       result = Dir.chdir(tmp) do
+        replacements.unshift([/^#{Regexp.quote(Dir.pwd)}/, pwd])
+
         stdout, stderr, status = Open3.capture3(*args)
 
         munge_output(stdout, stderr, replacements)


### PR DESCRIPTION
…tput

If the tmp dir is a symlink to another directory, after the code in
ruumba which does Dir.chdir(tmp) runs, we are not actually in the folder
returned from `FileUtils.mkdir_p(File.dirname(n))`. Delay creating the
regex replacements until we switch directories, so we can be sure we
have the correct directory name to replace in the output.

Closes #19.