### PR TITLE
Use default configuration file .ruumba.yml.

### DIFF
--- a/bin/ruumba
+++ b/bin/ruumba
@@ -104,5 +104,10 @@ rescue OptionParser::InvalidOption => e
   abort "An error occurred: #{e}. Run ruumba -h for help."
 end
 
+if !options[:arguments].include?('--config') && File.exist?('.ruumba.yml')
+  options[:arguments] << '--config'
+  options[:arguments] << File.expand_path('.ruumba.yml')
+end
+
 analyzer = Ruumba::Analyzer.new(options)
 exit(analyzer.run)


### PR DESCRIPTION
If .ruumba.yml exists and no config is specified on the command line,
default to using this file.

Closes #26.