### PR TITLE
Make sure tmpdir created by ruumba is removed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,4 +20,4 @@ Metrics/ClassLength:
   Max: 120
 
 Metrics/BlockLength:
-  Max: 110
+  Max: 130

--- a/spec/ruumba/analyzer_spec.rb
+++ b/spec/ruumba/analyzer_spec.rb
@@ -69,7 +69,13 @@ describe Ruumba::Analyzer do
         let(:temp_dir) { Pathname.new(Dir.mktmpdir) }
 
         before do
-          expect(Dir).to receive(:mktmpdir).and_return(temp_dir)
+          expect(Dir).to receive(:mktmpdir) do |*_args, &block|
+            block.call(temp_dir)
+          end
+        end
+
+        after do
+          FileUtils.remove_dir(temp_dir)
         end
 
         it_behaves_like 'linting a single file'
@@ -78,6 +84,10 @@ describe Ruumba::Analyzer do
       context 'when a temporary directory is configured' do
         let(:temp_folder_option) { temp_dir.to_s }
         let(:temp_dir) { Pathname.new(Dir.mktmpdir) }
+
+        after do
+          FileUtils.remove_dir(temp_dir)
+        end
 
         it_behaves_like 'linting a single file'
       end
@@ -126,7 +136,13 @@ describe Ruumba::Analyzer do
         let(:temp_dir) { Pathname.new(Dir.mktmpdir) }
 
         before do
-          expect(Dir).to receive(:mktmpdir).and_return(temp_dir)
+          expect(Dir).to receive(:mktmpdir) do |*_args, &block|
+            block.call(temp_dir)
+          end
+        end
+
+        after do
+          FileUtils.remove_dir(temp_dir)
         end
 
         it_behaves_like 'linting a list of files'

--- a/spec/ruumba/iterators_spec.rb
+++ b/spec/ruumba/iterators_spec.rb
@@ -41,6 +41,10 @@ describe Ruumba::Iterators::DirectoryIterator do
       end
     end
 
+    after do
+      FileUtils.remove_dir(target_dir)
+    end
+
     context 'when nil is passed as the directory' do
       let(:input_list) { nil }
 

--- a/spec/ruumba/rubocop_runner_spec.rb
+++ b/spec/ruumba/rubocop_runner_spec.rb
@@ -20,6 +20,10 @@ describe Ruumba::RubocopRunner do
       expect(status).to receive(:exitstatus).and_return(exitstatus)
     end
 
+    after do
+      FileUtils.remove_dir(target)
+    end
+
     it 'returns the exitstatus from rubocop' do
       expect(runner.execute).to eq(exitstatus)
     end


### PR DESCRIPTION
Previously, the directories created remained and required manual
cleanup.