### PR TITLE
Preserve ruby comments so we can use it to disable cops inline

### DIFF
--- a/lib/ruumba/parser.rb
+++ b/lib/ruumba/parser.rb
@@ -65,8 +65,13 @@ module Ruumba
 
     def extract_match(file_text, start_index, end_index)
       file_text[start_index...end_index].tap do |region|
-        # if this is a ruby comment inside, replace the whole match with spaces
-        region.gsub!(/[^\r\n]/, ' ') if region[0] == '#'
+        # if there is a ruby comment inside, replace the beginning of each line
+        # with the '#' so we end up with valid ruby
+
+        if region[0] == '#'
+          region.gsub!(/^ /, '#')
+          region.gsub!(/^(?!#)/, '#')
+        end
       end
     end
   end

--- a/spec/ruumba/parser_spec.rb
+++ b/spec/ruumba/parser_spec.rb
@@ -29,30 +29,41 @@ describe Ruumba::Parser do
     end
 
     it 'does extract single line ruby comments from an ERB template' do
-      erb = <<~RHTML
-        <% puts 'foo'
-        # that puts is ruby code
-        bar %>
-      RHTML
+      erb =
+        <<~RHTML
+          <% puts 'foo'
+          # that puts is ruby code
+          bar %>
+        RHTML
 
-      parsed = <<~RUBY
-           puts 'foo'
-        # that puts is ruby code
-        bar
-      RUBY
+      parsed =
+        <<~RUBY
+             puts 'foo'
+          # that puts is ruby code
+          bar
+        RUBY
 
       expect(analyzer.extract(erb)).to eq(parsed)
     end
 
     it 'does not extract ruby comments from interpolated code' do
-      erb = <<~RHTML
-        <%# this is a multiline comment
-            interpolated in the ERB template
-            it should resolve to nothing %>
-        <% puts 'foo' %>
-      RHTML
+      erb =
+        <<~RHTML
+          <%# this is a multiline comment
+              interpolated in the ERB template
+              it should be inside a comment %>
+          <% puts 'foo' %>
+        RHTML
 
-      expect(analyzer.extract(erb)).to eq("\n\n\n   puts 'foo'\n")
+      parsed =
+        <<~RUBY
+            # this is a multiline comment
+          #   interpolated in the ERB template
+          #   it should be inside a comment
+             puts 'foo'
+        RUBY
+
+      expect(analyzer.extract(erb)).to eq(parsed)
     end
 
     it 'extracts and converts lines using <%== for the raw helper' do


### PR DESCRIPTION
<%# rubocop:disable SomeCop %>
<% code_which_causes_a_violation %>
<%# rubocop:enable SomeCop %>