### PR TITLE
Support stdin auto-correct with --format json (as used by ale and possibly others)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,4 +105,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   2.0.2
+   1.17.3

--- a/lib/ruumba/correctors.rb
+++ b/lib/ruumba/correctors.rb
@@ -33,7 +33,7 @@ module Ruumba
         [stdout, stderr].each do |output|
           next if output.nil? || output.empty?
 
-          matches = output.scan(/\A(.*^====================)?$(.*)\z/m)
+          matches = output.scan(/\A(.*====================)?$(.*)\z/m)
 
           next if matches.empty?
 

--- a/spec/ruumba/correctors_spec.rb
+++ b/spec/ruumba/correctors_spec.rb
@@ -120,6 +120,22 @@ describe Ruumba::Correctors::StdinCorrector do
 
       expect(stdout).to eq(stdout_replaced)
     end
+
+    context 'when outputting in JSON format' do
+      let(:stdout_base) do
+        <<~STDOUT
+          {"metadata":{"rubocop_version":"0.74.0","ruby_engine":"ruby","ruby_version":"2.6.3","ruby_patchlevel":"62","ruby_platform":"x86_64-linux"},"files":[{"path":"app/views/file.rb","offenses":[{"severity":"convention","message":"Surrounding space missing in default value assignment.","cop_name":"Layout/SpaceAroundEqualsInParameterDefault","corrected":true,"location":{"start_line":17,"start_column":31,"last_line":17,"last_column":31,"length":1,"line":17,"column":31}}]}],"summary":{"offense_count":1,"target_file_count":1,"inspected_file_count":1}}====================
+          #{new_contents}
+        STDOUT
+      end
+      it 'replaces the output contents with the corrected output' do
+        expect(corrector).to receive(:handle_corrected_output).with(old_digest, "\n#{new_contents}\n", original_contents) { |&block| block.call("#{new_contents} - fixed") }
+
+        corrector.correct(stdout, stderr, file_mappings)
+
+        expect(stdout).to eq(stdout_replaced)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The regex configured as too strict since the json is output first then delimited by the ====================. Relax the match er slightly so we can use auto-correct from both. 