### PR TITLE
Fix using auto-correct with ERBs with comments

### DIFF
--- a/lib/ruumba/parser.rb
+++ b/lib/ruumba/parser.rb
@@ -115,7 +115,9 @@ module Ruumba
         if region[0] == '#'
           region.gsub!(/^ /, '#')
           region.gsub!(/^(?!#)/, '#')
-        elsif match_marker
+        end
+
+        if match_marker
           region.prepend("\n", match_marker, "\n")
           region.concat("\n", match_marker, "\n")
         end

--- a/spec/ruumba/parser_spec.rb
+++ b/spec/ruumba/parser_spec.rb
@@ -84,5 +84,38 @@ describe Ruumba::Parser do
 
       expect(analyzer.extract(erb)).to eq(' ' * 46)
     end
+
+    it 'extracts comments on the same line' do
+      erb = '<% if (foo = bar) %><%# should always be truthy %>'
+
+      expect(analyzer.extract(erb))
+        .to eq('   if (foo = bar) ;    # should always be truthy   ')
+    end
+
+    context 'when configured with a region marker' do
+      let(:analyzer) { described_class.new('mark') }
+
+      it 'extracts comments on the same line' do
+        erb = '<% if (foo = bar) %><%# should always be truthy %>'
+
+        # rubocop:disable Layout/TrailingWhitespace
+        ruby =
+          <<~RUBY
+              
+            mark_0000000001
+             if (foo = bar) 
+            mark_0000000001
+            ;    
+            mark_0000000002
+            # should always be truthy 
+            mark_0000000002
+              
+          RUBY
+          .chomp
+        # rubocop:enable Layout/TrailingWhitespace
+
+        expect(analyzer.extract(erb)).to eq(ruby)
+      end
+    end
   end
 end

--- a/spec/ruumba/parser_spec.rb
+++ b/spec/ruumba/parser_spec.rb
@@ -3,13 +3,13 @@
 require 'spec_helper'
 
 describe Ruumba::Parser do
-  let(:analyzer) { described_class.new }
+  let(:parser) { described_class.new }
 
   describe '#extract' do
     it 'extracts one line of Ruby code from an ERB template' do
       erb = "<%= puts 'Hello, world!' %>"
 
-      expect(analyzer.extract(erb)).to eq("    puts 'Hello, world!'   ")
+      expect(parser.extract(erb)).to eq("    puts 'Hello, world!'   ")
     end
 
     it 'extracts many lines of Ruby code from an ERB template' do
@@ -19,13 +19,13 @@ describe Ruumba::Parser do
         <% baz %>
       RHTML
 
-      expect(analyzer.extract(erb)).to eq("    puts 'foo'   \n    puts 'bar'   \n   baz   \n")
+      expect(parser.extract(erb)).to eq("    puts 'foo'   \n    puts 'bar'   \n   baz   \n")
     end
 
     it 'extracts multiple interpolations per line' do
       erb = "<%= puts 'foo' %> then <% bar %>"
 
-      expect(analyzer.extract(erb)).to eq("    puts 'foo' ;           bar   ")
+      expect(parser.extract(erb)).to eq("    puts 'foo' ;           bar   ")
     end
 
     it 'does extract single line ruby comments from an ERB template' do
@@ -45,7 +45,7 @@ describe Ruumba::Parser do
         RUBY
       # rubocop:enable Layout/TrailingWhitespace
 
-      expect(analyzer.extract(erb)).to eq(parsed)
+      expect(parser.extract(erb)).to eq(parsed)
     end
 
     it 'does not extract ruby comments from interpolated code' do
@@ -67,7 +67,7 @@ describe Ruumba::Parser do
         RUBY
       # rubocop:enable Layout/TrailingWhitespace
 
-      expect(analyzer.extract(erb)).to eq(parsed)
+      expect(parser.extract(erb)).to eq(parsed)
     end
 
     it 'extracts and converts lines using <%== for the raw helper' do
@@ -75,25 +75,25 @@ describe Ruumba::Parser do
         <span class="test" <%== 'style="display: none;"' if num.even? %>>
       RHTML
 
-      expect(analyzer.extract(erb))
+      expect(parser.extract(erb))
         .to eq("                    raw 'style=\"display: none;\"' if num.even?    \n")
     end
 
     it 'does not extract code from lines without ERB interpolation' do
       erb = "<h1>Dead or alive, you're coming with me.</h1>"
 
-      expect(analyzer.extract(erb)).to eq(' ' * 46)
+      expect(parser.extract(erb)).to eq(' ' * 46)
     end
 
     it 'extracts comments on the same line' do
       erb = '<% if (foo = bar) %><%# should always be truthy %>'
 
-      expect(analyzer.extract(erb))
+      expect(parser.extract(erb))
         .to eq('   if (foo = bar) ;    # should always be truthy   ')
     end
 
     context 'when configured with a region marker' do
-      let(:analyzer) { described_class.new('mark') }
+      let(:parser) { described_class.new('mark') }
 
       it 'extracts comments on the same line' do
         erb = '<% if (foo = bar) %><%# should always be truthy %>'
@@ -114,7 +114,7 @@ describe Ruumba::Parser do
           .chomp
         # rubocop:enable Layout/TrailingWhitespace
 
-        expect(analyzer.extract(erb)).to eq(ruby)
+        expect(parser.extract(erb)).to eq(ruby)
       end
     end
   end


### PR DESCRIPTION
Because of a logic error in parser.rb, the closing markers for the replace regions are missing so the auto-correct code can no longer locate where to inject the auto-correct code returned from rubocop.