### PR TITLE
Strip trailing whitespace and newlines when not autocorrecting.

### DIFF
--- a/lib/ruumba/parser.rb
+++ b/lib/ruumba/parser.rb
@@ -35,6 +35,14 @@ module Ruumba
       # left so they match the original again
       extracted_ruby.gsub!(/   raw/, 'raw')
 
+      unless region_start_marker
+        add_newline = extracted_ruby =~ /\n\z/
+
+        extracted_ruby.gsub!(/\s+$/, '')
+
+        extracted_ruby << "\n" if add_newline
+      end
+
       extracted_ruby
     end
 

--- a/spec/ruumba/parser_spec.rb
+++ b/spec/ruumba/parser_spec.rb
@@ -9,7 +9,7 @@ describe Ruumba::Parser do
     it 'extracts one line of Ruby code from an ERB template' do
       erb = "<%= puts 'Hello, world!' %>"
 
-      expect(parser.extract(erb)).to eq("    puts 'Hello, world!'   ")
+      expect(parser.extract(erb)).to eq("    puts 'Hello, world!'")
     end
 
     it 'extracts many lines of Ruby code from an ERB template' do
@@ -19,13 +19,26 @@ describe Ruumba::Parser do
         <% baz %>
       RHTML
 
-      expect(parser.extract(erb)).to eq("    puts 'foo'   \n    puts 'bar'   \n   baz   \n")
+      expect(parser.extract(erb)).to eq("    puts 'foo'\n    puts 'bar'\n   baz\n")
+    end
+
+    it 'extracts removes multiple trailing newlines' do
+      erb = <<~RHTML
+        <%= puts 'foo' %>
+        <%= puts 'bar' %>
+        <% baz %>
+
+        <br />
+        <br />
+      RHTML
+
+      expect(parser.extract(erb)).to eq("    puts 'foo'\n    puts 'bar'\n   baz\n")
     end
 
     it 'extracts multiple interpolations per line' do
       erb = "<%= puts 'foo' %> then <% bar %>"
 
-      expect(parser.extract(erb)).to eq("    puts 'foo' ;           bar   ")
+      expect(parser.extract(erb)).to eq("    puts 'foo' ;           bar")
     end
 
     it 'does extract single line ruby comments from an ERB template' do
@@ -40,7 +53,7 @@ describe Ruumba::Parser do
         <<~RUBY
              puts 'foo'
           # that puts is ruby code
-          bar   
+          bar
         RUBY
 
       expect(parser.extract(erb)).to eq(parsed)
@@ -59,8 +72,8 @@ describe Ruumba::Parser do
         <<~RUBY
             # this is a multiline comment
           #   interpolated in the ERB template
-          #   it should be inside a comment   
-             puts 'foo'   
+          #   it should be inside a comment
+             puts 'foo'
         RUBY
 
       expect(parser.extract(erb)).to eq(parsed)
@@ -72,20 +85,20 @@ describe Ruumba::Parser do
       RHTML
 
       expect(parser.extract(erb))
-        .to eq("                    raw 'style=\"display: none;\"' if num.even?    \n")
+        .to eq("                    raw 'style=\"display: none;\"' if num.even?\n")
     end
 
     it 'does not extract code from lines without ERB interpolation' do
       erb = "<h1>Dead or alive, you're coming with me.</h1>"
 
-      expect(parser.extract(erb)).to eq(' ' * 46)
+      expect(parser.extract(erb)).to eq('')
     end
 
     it 'extracts comments on the same line' do
       erb = '<% if (foo = bar) %><%# should always be truthy %>'
 
       expect(parser.extract(erb))
-        .to eq('   if (foo = bar) ;    # should always be truthy   ')
+        .to eq('   if (foo = bar) ;    # should always be truthy')
     end
 
     context 'when configured with a region marker' do


### PR DESCRIPTION
Since we extract the ruby code from inside the template and run rubocop
on it, keeping the column positions (filling with whitespace) so that we
can find where the code came from when auto correcting, most layout and
style cops don't make much sense with ruumba.

If we are not auto-correcting (which is experimental currently anyway),
we can strip out the trailing spaces and the trailing newlines to avoid
those violations. We will still get indention cop violations etc, but
perhaps this at least gives a slightly better out of the box experience.

Closes #54